### PR TITLE
Update the version of tidy recommended for use with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Before beginning, install MySQL, HTMLTidy and Ruby:
 
 ```
 # OS X ...
-brew install homebrew/dupes/tidy mysql rbenv ruby-build
+brew install tidy-html5 mysql rbenv ruby-build
 rbenv install $(cat .ruby-version)
 
 # ... or Linux (Debian)


### PR DESCRIPTION
I couldn't get tests passing with the recommended version, which wouldn't install, I'd get:

```
> brew install homebrew/dupes/tidy                                                                                                                                         Luke@Lukes-MacBook-Pro[15:55]
Error: No available formula with the name "homebrew/dupes/tidy"
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
Error: No formulae found in taps.
```

It looks like this has been dropped from homebrew in favour of tidy-html5:
https://github.com/Homebrew/homebrew-dupes/pull/456

I ran `brew install tidy-html5` and now all the tests pass for me locally ¯_(ツ)_/¯
