### PR TITLE
Paginate member votes page

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -20,7 +20,17 @@ class DivisionsController < ApplicationController
       if @member.nil?
         render 'members/member_not_found', status: 404
       else
-        @members = @member.person.members.order(entered_house: :desc)
+        @divisions_or_nil_with_member = []
+        @member.person.members.order(entered_house: :desc).each do |member|
+          if member.divisions_possible.any?
+            member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc).each do |division|
+              @divisions_or_nil_with_member << { division: division, member: member }
+            end
+          else
+            @divisions_or_nil_with_member << { division: nil, member: member }
+          end
+        end
+        @divisions_or_nil_with_member = Kaminari.paginate_array(@divisions_or_nil_with_member).page(params[:page]).per(100)
 
         render 'index_with_member'
       end

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -20,6 +20,8 @@ class DivisionsController < ApplicationController
       if @member.nil?
         render 'members/member_not_found', status: 404
       else
+        @members = @member.person.members.order(entered_house: :desc)
+
         render 'index_with_member'
       end
     else

--- a/app/views/divisions/index_with_member.html.haml
+++ b/app/views/divisions/index_with_member.html.haml
@@ -14,7 +14,7 @@
     - if m[:division].present?
       = render m[:division], member: m[:member]
     - else
-      %li
+      %li.object-item
         No votes listed as
         = member_type_party_place_sentence(m[:member])
 

--- a/app/views/divisions/index_with_member.html.haml
+++ b/app/views/divisions/index_with_member.html.haml
@@ -9,5 +9,14 @@
 
 %p All votes #{@member.full_name_no_electorate} could have attended.
 
-- @members.each do |member|
-  = render "divisions", member: @member, divisions: member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc)
+%ol.divisions-list.list-unstyled{class: active_house_for_list_class(@house)}
+  - @divisions_or_nil_with_member.each do |m|
+    - if m[:division].present?
+      = render m[:division], member: m[:member]
+    - else
+      %li
+        No votes listed as
+        = member_type_party_place_sentence(m[:member])
+
+.index-pagination
+  = paginate @divisions_or_nil_with_member, window: 2, outer_window: 3

--- a/app/views/divisions/index_with_member.html.haml
+++ b/app/views/divisions/index_with_member.html.haml
@@ -9,5 +9,5 @@
 
 %p All votes #{@member.full_name_no_electorate} could have attended.
 
-- @member.person.members.order(entered_house: :desc).each do |member|
+- @members.each do |member|
   = render "divisions", member: @member, divisions: member.divisions_possible.order(date: :desc, clock_time: :desc, name: :asc)

--- a/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Christine_Milne&mpc=Tasmania&house=senate&display=everyvote.html
@@ -131,6 +131,7 @@ attendance
 </p>
 </article>
 </a></li>
+
 <li>
 <a class="object-item panel-link" href="/divisions/senate/2009-12-30/8" title="See full division page for Proceedural ban of flatulence during divisions."><article class="division-item division-outcome-not-passed division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
@@ -155,6 +156,7 @@ attendance
 </p>
 </article>
 </a></li>
+
 <li>
 <a class="object-item panel-link" href="/divisions/senate/2009-11-30/8" title="See full division page for Carbon Pollution Reduction Scheme (Cprs Fuel Credits) Bill 2009 [No. 2]; Carbon Pollution Reduction Scheme Amendment (Household Assistance) Bill 2009 [No. 2] — Third Reading."><article class="division-item division-outcome-not-passed division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
@@ -179,6 +181,7 @@ attendance
 </p>
 </article>
 </a></li>
+
 <li>
 <a class="object-item panel-link" href="/divisions/senate/2009-11-25/8" title="See full division page for Carbon Pollution Reduction Scheme Legislation."><article class="division-item division-outcome-not-passed division-status-raw">
 <div class="division-edit-notice pull-right text-muted">
@@ -205,7 +208,9 @@ attendance
 </a></li>
 
 </ol>
+<div class="index-pagination">
 
+</div>
 </div>
 <footer class="site-footer">
 <div class="footer-main">

--- a/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Kevin_Rudd&mpc=Griffith&house=representatives&display=everyvote.html
@@ -133,6 +133,7 @@ attendance
 </p>
 </article>
 </a></li>
+
 <li>
 <a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-outcome-not-passed division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
@@ -161,7 +162,9 @@ attendance
 </a></li>
 
 </ol>
+<div class="index-pagination">
 
+</div>
 </div>
 <footer class="site-footer">
 <div class="footer-main">

--- a/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
+++ b/spec/fixtures/static_pages/mp.php?mpn=Tony_Abbott&mpc=Warringah&house=representatives&display=everyvote.html
@@ -133,6 +133,7 @@ attendance
 </p>
 </article>
 </a></li>
+
 <li>
 <a class="object-item panel-link" href="/divisions/representatives/2006-12-06/3" title="See full division page for Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo Research Amendment Bill 2006 - Consideration in Detail."><article class="division-item division-outcome-not-passed division-status-edited">
 <div class="division-edit-notice pull-right text-muted">
@@ -161,7 +162,9 @@ attendance
 </a></li>
 
 </ol>
+<div class="index-pagination">
 
+</div>
 </div>
 <footer class="site-footer">
 <div class="footer-main">


### PR DESCRIPTION
This paginates the votes in the individual MP’s all votes page. If we don't have any votes for one of the person’s memberships, then the current notice is still shown as usual.

It’s a big performance improvement to the page, taking it from around 14s for a member I was looking at, to 3s. Closes #135.

@henare this was a bit tricker than I through before getting into it ;-) I've done this as a PR for code review/get your thoughts. It feels quite hacky.

Is it clear from the code what’s going on here?
Could there be a clearer name for the @divisions_or_nil_with_member collection?
